### PR TITLE
feat(renovate): configure Docker digest pinning

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,7 @@ jobs:
       - name: "Render book as GitBook"
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3.0.0
         with:
-          image: ghcr.io/fsbcg-ubt/docker-bookdown@sha256:3e45bec722a0b48560338f516ba2737b2b07bddf38a81aade9ff2b207e1822bc
+          image: ghcr.io/fsbcg-ubt/docker-bookdown:0.3.7@sha256:3e45bec722a0b48560338f516ba2737b2b07bddf38a81aade9ff2b207e1822bc
           options: --mount src=${{ github.workspace }},target=/book,type=bind
           run: Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"
       - name: "Upload artifact"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: "Render book as GitBook"
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3.0.0
         with:
-          image: ghcr.io/fsbcg-ubt/docker-bookdown@sha256:3e45bec722a0b48560338f516ba2737b2b07bddf38a81aade9ff2b207e1822bc
+          image: ghcr.io/fsbcg-ubt/docker-bookdown:0.3.7@sha256:3e45bec722a0b48560338f516ba2737b2b07bddf38a81aade9ff2b207e1822bc
           options: --mount src=${{ github.workspace }},target=/book,type=bind
           run: Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"
       - name: "Upload artifact"

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,16 @@
     "docker:pinDigests",
     "helpers:pinGitHubActionDigests"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
+      "matchStrings": [
+        "image:\\s+(?<depName>[^\\s:]+?):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
   "packageRules": [
     {
       "matchDatasources": ["github-tags"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests"
   ],
   "packageRules": [
     {
       "matchDatasources": ["github-tags"],
       "groupName": "github workflow actions",
+      "schedule": ["every weekend"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "groupName": "docker dependencies",
       "schedule": ["every weekend"]
     }
   ]


### PR DESCRIPTION
## Summary

This PR configures Docker digest pinning in Renovate to enhance build reproducibility and security for our Docker images used in GitHub Actions workflows.

## Changes

- **Updated `renovate.json`**:
  - Added `docker:pinDigests` preset to enable SHA256 digest pinning for Docker images
  - Added `helpers:pinGitHubActionDigests` for GitHub Actions (already manually pinned)
  - Switched from `config:base` to `config:recommended` for best practices
  - Configured Docker dependencies grouping with weekend schedule
  - **Added custom regex manager** to detect Docker images within GitHub Actions workflow files

- **Updated GitHub Actions workflows**:
  - Added version tag `0.3.7` to Docker image references in both `release.yml` and `pull_request.yml`
  - Format changed from `image@sha256:hash` to `image:tag@sha256:hash` for better version tracking

## Custom Regex Manager

Added a custom manager to detect Docker images in the `docker-run-action` parameters:
- Matches pattern: `image: registry/image:version@sha256:digest`