### PR TITLE
daten: Termine 2025

### DIFF
--- a/data/termine-erstiveranstaltungen.csv
+++ b/data/termine-erstiveranstaltungen.csv
@@ -1,9 +1,14 @@
 Datum;Uhrzeit;Veranstaltungen;Ort
-Ab 10.10.2022;;Mathe Vorkurs;[PDF für weitere Infos](https://www.studierendenkanzlei.uni-bayreuth.de/pool/dokumente/WS223_Vorkurs_Mathematik_Fak2.pdf)
-Donnerstag / 13.10.2022;16.00-17.30 Uhr;cmlife-Einführung;[Microsoft Teams](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fmeetup-join%2F19%3Ameeting_OTg5NjRiYjUtNTVjYS00YzQxLTkzNGEtYzM5Yzc4MjQ3N2E2%40thread.v2%2F0%3Fcontext%3D%257b%2522Tid%2522%253a%252254d63e24-ac6d-4c5e-a8d6-ba978a0b286e%2522%252c%2522Oid%2522%253a%2522d0a0a0c7-d4e1-4183-a6d9-25da01b76d00%2522%257d%26anon%3Dtrue&type=meetup-join&deeplinkId=729dfbf6-a209-4eda-86b1-8e1bf5775204&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
-Freitag / 14.10.2022;ab 19 Uhr;Erste Kneipentour;Treffpunkt am Sternplatz, Mit [Anmeldung](https://docs.google.com/forms/d/e/1FAIpQLSdjVTBq7O4i-25DDm3M6D88jE9dsmpttXbu5LEIyRchHwVPHg/viewform?usp=sf_link)
-Samstag / 15.10.2022;ab 13 Uhr;Stadtrallye; bis abends, Mit [Anmeldung](https://docs.google.com/forms/d/e/1FAIpQLSd7NF7vTLQecO1bXNNFB79B2CYNihUT_3gWKQ6hdZf570cChw/viewform?usp=sf_link)
-Montag / 17.10.2022;17 Uhr;Willkommen im Dschungel! Tipps & Tricks rund um den Studieneinstieg;H14 im NW1
-Montag / 17.10.2022;18 Uhr;Immatrikulationsstunde für Erstsemester durch den Präsidenten;Audimax
-Freitag / 21.10.2022;ab 19 Uhr;Zweite Kneipentour;Treffpunkt am Sternplatz, Mit [Anmeldung](https://docs.google.com/forms/d/e/1FAIpQLSdJ97ZQwDVp8xfNNddYxedlJN5-n7pv-FhQkulid8Ga5c-FTQ/viewform?usp=sf_link)
-Samstag / 22.10.2022;ab 13 Uhr;Fragestunde der Fachschaft;[Zoom](https://uni-bayreuth.zoom.us/j/66785120690?pwd=dE1jM0I2SjJ1eGYveUdtZmhHaWs4dz09)
+06.-10.10.2025;;Mathe Vorkurs;[PDF für weitere Infos](https://elearning.uni-bayreuth.de/enrol/index.php?id=45664)
+Mittwoch / 08.10.2025;16.00 Uhr;"Wie geht studieren?"; [Zoom]
+Donnerstag / 09.10.2025;16.00-17.30 Uhr;cmlife-Einführung;[Microsoft Teams](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fmeetup-join%2F19%3Ameeting_OTg5NjRiYjUtNTVjYS00YzQxLTkzNGEtYzM5Yzc4MjQ3N2E2%40thread.v2%2F0%3Fcontext%3D%257b%2522Tid%2522%253a%252254d63e24-ac6d-4c5e-a8d6-ba978a0b286e%2522%252c%2522Oid%2522%253a%2522d0a0a0c7-d4e1-4183-a6d9-25da01b76d00%2522%257d%26anon%3Dtrue&type=meetup-join&deeplinkId=729dfbf6-a209-4eda-86b1-8e1bf5775204&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
+Donnerstag / 09.10.2025;ab 19 Uhr;Erste Kneipentour;Treffpunkt am Brunnen vorm neuen Schloss, Mit Anmeldung per Email
+Samstag / 11.10.2025;13-18/19 Uhr;Stadtrallye; Treffpunkt: Rondell, Mit Anmeldung per Email
+Montag / 13.10.2025;17 Uhr;Willkommen im Dschungel! Tipps & Tricks rund um den Studieneinstieg;H14 im NW1
+Mittwoch / 15.10.2025;19 Uhr;Erste Fachschaftsitzung; H13 in NW1
+Donnerstag / 16.10.2025;ab 19 Uhr;Kneipentour Geo Ressort;Treffpunkt am Brunnen vorm neuen Schloss
+Freitag / 17.10.2025;ab 19 Uhr;Zweite Kneipentour;Treffpunkt am Brunnen vorm neuen Schloss, Mit Anmeldung
+Dienstag / 21.10.2025;ab 18:30 Uhr;Spieleabend mit allen Fakultäten;NW3
+Donnerstag / 23.10.2025;19 Uhr;Pub Quiz;H13 (NW1)
+Mittwoch / 29.10.2025;Abends;Schlacht der Fakultäten;Überall auf dem Campus
+Freitag-Sonntag / 07.-09.11.2025;07. ab abends und am 09. bis nachmittags;Wallenfels Wochenende;Wallenfels

--- a/data/termine-semester.csv
+++ b/data/termine-semester.csv
@@ -1,16 +1,16 @@
 Termin;Datum
-Semesterbeginn;01.10.2022
-Semesterende;31.03.2023
-Vorlesungsbeginn;17.10.2022
-Vorlesungsende;10.02.2023
-Akademische Jahresfeier;24.11.2022, Beginn voraussichtlich 17 Uhr
-Vorlesungsfrei;24.12.2022 bis 06.01.2023 (Weihnachtsferien)
-Rückmeldung für das SoSe 2023;16.01.2023 bis 22.02.2023
+Semesterbeginn;01.10.2025
+Semesterende;31.03.2026
+Vorlesungsbeginn;13.10.2025
+Immatrikulationsstunde für Erstsemester;13.10.2025, 18 Uhr im Audimax
+Vorlesungsende;06.02.2026
+Vorlesungsfrei;22.12.2025 bis 06.01.2026 (Weihnachtsferien)
+Rückmeldung für das SoSe 2026;15.01.2026 bis 15.02.2026
 ;
-Semesterbeginn;01.04.2023
-Semesterende;30.09.2023
-Vorlesungsbeginn;17.04.2023
-Vorlesungsende;21.07.2023
+Semesterbeginn;01.04.2026
+Semesterende;30.09.2026
+Vorlesungsbeginn;13.04.2026
+Vorlesungsende;17.07.2026
 UNIKAT – Das Sommerevent;noch kein Termin
-Vorlesungsfrei;30.05.2023 (Dienstag nach Pfingsten)
-Rückmeldung für das WiSe 2023/24;12.06.2023 bis 25.07.2023
+Vorlesungsfrei;26.05.2026 (Dienstag nach Pfingsten)
+Rückmeldung für das WiSe 2026/27;15.06.2026 bis 15.07.2026


### PR DESCRIPTION
Aktualisierung der Termindateien für 2025/2026:

**Änderungen:**
- termine-erstiveranstaltungen.csv: Termine von 2022 auf 2025 aktualisiert
- Erweiterung auf 14 Erstiveranstaltungen (vorher 8)
- Neue Veranstaltungen: "Wie geht studieren?", Spieleabend, Pub Quiz, Schlacht der Fakultäten, Wallenfels Wochenende
- Treffpunkte geändert (Brunnen vorm neuen Schloss statt Sternplatz)
- termine-semester.csv: Semesterdaten für WS 2025/26 und SoSe 2026
- Immatrikulationsstunde am 13.10.2025 hinzugefügt
- Angepasste Vorlesungszeiten und Rückmeldefristen