### PR TITLE
pwa: Firefox-kompatiblen Manifest-Test verwenden

### DIFF
--- a/pwa/tests/e2e/specs/manifest.spec.ts
+++ b/pwa/tests/e2e/specs/manifest.spec.ts
@@ -186,6 +186,9 @@ test.describe('Web App Manifest', () => {
     // to avoid Firefox CDP protocol error (NS_ERROR_FAILURE)
     const manifestText = await pwaPage.page.evaluate(async () => {
       const response = await fetch('/manifest.json');
+      if (!response.ok) {
+        throw new Error('Failed to fetch manifest.json');
+      }
       return await response.text();
     });
 

--- a/pwa/tests/e2e/specs/manifest.spec.ts
+++ b/pwa/tests/e2e/specs/manifest.spec.ts
@@ -182,8 +182,12 @@ test.describe('Web App Manifest', () => {
   });
 
   test('BASE_PATH template is replaced in manifest', async ({ pwaPage }) => {
-    const response = await pwaPage.page.goto('/manifest.json');
-    const manifestText = await response?.text();
+    // Use in-browser fetch instead of page.goto + response.text()
+    // to avoid Firefox CDP protocol error (NS_ERROR_FAILURE)
+    const manifestText = await pwaPage.page.evaluate(async () => {
+      const response = await fetch('/manifest.json');
+      return await response.text();
+    });
 
     expect(manifestText).not.toContain('{{BASE_PATH}}');
   });


### PR DESCRIPTION
## Zusammenfassung

E2E-Test `BASE_PATH template is replaced in manifest` schlägt auf Firefox fehl und blockiert PR #146.

## Änderungen

### Manifest-Test korrigiert (`pwa/tests/e2e/specs/manifest.spec.ts`)

**Problem:** `page.goto('/manifest.json')` + `response.text()` löst auf Firefox einen CDP-Protokollfehler aus (`NS_ERROR_FAILURE` bei `Network.getResponseBody`)

**Lösung:**
- `page.evaluate()` mit nativer `fetch()`-API statt `page.goto()` + `response.text()`
- Konsistent mit der bestehenden `getManifest()`-Methode in `pwa-page.ts`

## Warum wichtig?

**Vorher:** Test schlägt auf Firefox fehl, alle anderen Browser bestehen — blockiert alle offenen PRs mit PWA-Änderungen
**Nachher:** Test läuft browserübergreifend stabil über die native Fetch-API